### PR TITLE
security: add CODEOWNERS, SECURITY.md, and dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for this repository
+* @redhat-actions/maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report vulnerabilities through GitHub's private security advisory feature:
+
+1. Go to the [Security Advisories page](https://github.com/redhat-actions/oc-login/security/advisories)
+2. Click "New draft security advisory"
+3. Fill in the details of the vulnerability
+
+Alternatively, you can email the Red Hat Product Security team at secalert@redhat.com.
+
+## Supported Versions
+
+Only the latest major version is actively supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | Yes                |
+| < 1.0   | No                 |


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS` with `@redhat-actions/maintainers` as default owner
- Add `SECURITY.md` with vulnerability reporting instructions
- Add `.github/dependabot.yml` for automated npm and GitHub Actions dependency updates

### Repository settings applied via API (already active)

- Enabled secret scanning and push protection
- Set default workflow token permissions to read-only
- Disabled workflow PR approval capability

## Test plan

- [x] CODEOWNERS syntax is valid
- [x] Dependabot config validates
- [ ] Dependabot begins creating update PRs on schedule
- [ ] Secret scanning shows as enabled in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)