### PR TITLE
Prepare v2.0 release: changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # oc-login Changelog
 
+## v2.0
+
+### Breaking Changes
+- **Node.js 24 runtime**: The action now runs on Node.js 24. GitHub runners must support `node24` actions.
+- **KUBECONFIG set before login**: The action now sets `KUBECONFIG` to `$GITHUB_WORKSPACE/kubeconfig.yaml` before running `oc login`, so `oc` writes directly to an isolated file instead of `~/.kube/config`. This fixes race conditions on self-hosted runners but may affect workflows that depend on the previous behavior of writing to `~/.kube/config` first.
+- **Post-step logout**: The action now logs out of OpenShift and removes the kubeconfig file at the end of the job by default. Set `logout: false` to preserve the previous behavior.
+
+### Features
+- **OIDC authentication** (#42): New `use_oidc` and `oidc_audience` inputs enable authentication using GitHub's OIDC tokens for workload identity federation. Requires the cluster's API server to be configured with GitHub as an OIDC provider.
+- **Optional server URL** (#24): `openshift_server_url` is no longer required. When omitted, `oc login` uses the existing kubeconfig context on the runner.
+- **Post-step logout** (#2): New `logout` input (default: `true`) controls whether the action logs out and cleans up the kubeconfig at the end of the job. Recommended for self-hosted runners.
+- **Race condition fix** (#41): Concurrent jobs on self-hosted runners no longer clobber each other's kubeconfig by writing to a shared `~/.kube/config`.
+
+### Dependencies
+- Upgraded `@actions/core` to v3.0.1, `@actions/exec` to v3.0.0, `js-yaml` to v5.2.1
+- Upgraded TypeScript to 6.x, ESLint to 10.x with flat config
+- Upgraded `@vercel/ncc` to 0.44.x
+- Bundle size reduced from 539kB to 86kB
+
+### CI & Infrastructure
+- Migrated all workflows to `ubuntu-24.04` with `actions/checkout@v7` and `actions/setup-node@v7`
+- Added `permissions: contents: read` and concurrency groups to all workflows
+- Added path filters to avoid unnecessary CI runs
+- Replaced archived `gaurav-nelson/github-action-markdown-link-check` with `lycheeverse/lychee-action@v2`
+- Removed dead workflows: CRDA vulnerability scan, OpenShift 3 tests, broken multiplatform and OpenShift cron jobs
+- Added Dependabot configuration for npm and GitHub Actions dependencies
+- Added `.github/CODEOWNERS`
+- Enabled secret scanning and push protection
+
+### Tests
+- Added unit tests for auth and kubeconfig modules (29 -> 52 tests)
+- Added `inputs-outputs.test.ts` to verify action.yml and TypeScript enum consistency
+
 ## v1.3
 - Update action to run on Node20. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See the [OpenShift Documentation](https://docs.openshift.com/enterprise/3.0/dev_
 ```yaml
 steps:
   - name: Authenticate and set context
-    uses: redhat-actions/oc-login@v1
+    uses: redhat-actions/oc-login@v2
     env:
       # These can be stored in secrets, if desired.
       OPENSHIFT_USER: my-username

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oc-login",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

- Updates `CHANGELOG.md` with comprehensive v2.0 release notes covering all changes since v1.3
- Bumps `package.json` version from 1.0.0 to 2.0.0
- Updates README usage example from `@v1` to `@v2`

## Release notes preview

### Breaking Changes
- Node.js 24 runtime
- KUBECONFIG set before login (race condition fix changes behavior)
- Post-step logout enabled by default

### Features
- OIDC authentication (#42)
- Optional server URL (#24)
- Post-step logout (#2)
- Race condition fix (#41)

### Also includes
- Major dependency upgrades (@actions/core v3, @actions/exec v3, TypeScript 6, ESLint 10)
- CI modernization (ubuntu-24.04, actions v7, security defaults)
- Security hardening (secret scanning, CODEOWNERS, dependabot)
- Test coverage increase (29 -> 52 tests)

## Test plan

- [x] Changelog accurately reflects all commits since v1.3
- [x] Version bump consistent across package.json
- [x] README example updated to v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)