### PR TITLE
Add workflow to rebuild bundle on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -1,0 +1,33 @@
+name: Rebuild bundle for Dependabot PRs
+
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+    paths:
+      - 'package*.json'
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - run: npm ci
+
+      - run: npm run bundle
+
+      - name: Commit updated bundle
+        run: |
+          if git diff --quiet dist/; then
+            echo "Bundle is up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add dist/
+            git commit -m "Rebuild bundle after dependency update"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- Adds a new workflow that triggers on pushes to `dependabot/**` branches when `package*.json` changes
- Rebuilds the bundle (`npm run bundle`) and commits the result if it differs from what's checked in
- Fixes the recurring "Check Distribution" CI failure on Dependabot PRs (e.g. #70), where the bundle hash doesn't match because Dependabot doesn't run `npm run bundle` after updating dependencies

## Test plan
- [ ] Merge this PR, then re-run CI on #70 (or wait for the next Dependabot PR) and verify the rebuild workflow triggers and the bundle check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)