### PR TITLE
Fix broken links in link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# docs.redhat.com returns 403 for automated crawlers but links are valid for users
+https://docs.redhat.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 - Added `inputs-outputs.test.ts` to verify action.yml and TypeScript enum consistency
 
 ## v1.3
-- Update action to run on Node20. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20
+- Update action to run on Node20. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 
 ## v1.2
 - Update action to run on Node16. https://github.blog/changelog/2022-05-20-actions-can-now-run-in-a-node-js-16-runtime/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See the [OpenShift Documentation](https://docs.redhat.com/en/documentation/opens
     - The easiest way to get around this is to set the `insecure_skip_tls_verify` input to `true`.
     - You can also obtain the self-signed certificate data (from a `.crt` file) and use the `certificate_authority_data` input.
 5. Store the Server URL and any credentials (passwords, tokens, or certificates) in GitHub Secrets.
-    - [Refer to the GitHub documentation](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+    - [Refer to the GitHub documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets).
     - You can name them anything you like. See below for an example.
 6. Create your workflow.
 


### PR DESCRIPTION
## Summary

- Add `.lycheeignore` to exclude `docs.redhat.com`, which returns 403 to automated crawlers but links are valid for browser users
- Update GitHub encrypted secrets docs URL to its current location (was 301 redirecting)
- Add trailing slash to GitHub blog changelog URL (was 301 redirecting)

## Test plan

- [ ] Link checker workflow passes on this PR

Fixes: https://github.com/redhat-actions/oc-login/actions/runs/33514232260/job/99877093231

🤖 Generated with [Claude Code](https://claude.com/claude-code)